### PR TITLE
Set packages_dir to correct setup.py output path

### DIFF
--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -52,4 +52,5 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          packages_dir: action/package/dist/
           password: ${{secrets.PYPI_TOKEN}}


### PR DESCRIPTION
# Description
Fix packages_dir path to actual output path from previous step

# Issues
Validated https://github.com/NeonGeckoCom/neon-cli-client/pull/27
