### PR TITLE
Add optional MANIFEST.in tests to python build tests

### DIFF
--- a/.github/workflows/python_build_tests.yml
+++ b/.github/workflows/python_build_tests.yml
@@ -6,6 +6,14 @@ on:
         required: false
         type: string
         default: "3.8"
+      test_manifest:
+        required: false
+        type: boolean
+        default: false
+      manifest_ignored:
+        required: false
+        type: string
+        default: "test/*"
 jobs:
   py_build_tests:
     timeout-minutes: 15
@@ -22,4 +30,8 @@ jobs:
       - name: Build Distribution Packages
         run: |
           python setup.py bdist_wheel sdist
-
+      - name: Test Manifest
+        if: ${{ inputs.test_manifest }}
+        uses: tj-actions/check-manifest@v1
+        with:
+          args: --ignore ${{ inputs.manifest_ignored }}


### PR DESCRIPTION
# Description
Adds an option to test MANIFEST.in contents with Python Build Tests

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->