### PR TITLE
Negative Intent Tests

### DIFF
--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test_intents_ovos:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: [ '3.10' ]
@@ -39,7 +39,7 @@ jobs:
           pytest action/github/test/test_skill_intents.py
   test_intents_neon:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: [ 3.7, '3.10' ]

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -22,8 +22,6 @@ jobs:
         with:
           repository: NeonGeckoCom/.github
           path: action/github/
-          ref: FEAT_NegativeIntentTests
-          # TODO: Remove ref
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -52,8 +50,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: NeonGeckoCom/.github
-          ref: FEAT_NegativeIntentTests
-          # TODO: Remove ref
           path: action/github/
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           repository: NeonGeckoCom/.github
           path: action/github/
+          ref: FEAT_NegativeIntentTests
+          # TODO: Remove ref
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -50,6 +52,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: NeonGeckoCom/.github
+          ref: FEAT_NegativeIntentTests
+          # TODO: Remove ref
           path: action/github/
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -102,6 +102,13 @@ class TestSkillIntentMatching(unittest.TestCase):
                     intent_handler.reset_mock()
 
     def test_negative_intents(self):
+        last_message = None
+
+        def _on_message(msg):
+            nonlocal last_message
+            last_message = msg
+
+        self.bus.on("message", _on_message)
         intent_failure = Mock()
         self.intent_service.send_complete_intent_failure = intent_failure
         for lang in self.negative_intents.keys():
@@ -113,7 +120,7 @@ class TestSkillIntentMatching(unittest.TestCase):
                     intent_failure.assert_called_once_with(message)
                     intent_failure.reset_mock()
                 except AssertionError as e:
-                    raise AssertionError(utt) from e
+                    raise AssertionError(last_message) from e
 
 
 if __name__ == "__main__":

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -101,23 +101,19 @@ class TestSkillIntentMatching(unittest.TestCase):
                                              value, utt)
                     intent_handler.reset_mock()
 
-    @patch('ovos_utils.sound.play_error_sound')
-    def test_negative_intents(self, _):
-        intent_handler = Mock()
-        failure_event = "complete_intent_failure"
-        self.skill.events.add(failure_event, intent_handler)
+    def test_negative_intents(self):
+        intent_failure = Mock()
+        self.intent_service.send_complete_intent_failure = intent_failure
         for lang in self.negative_intents.keys():
             for utt in self.negative_intents[lang]:
                 message = Message('test_utterance',
                                   {"utterances": [utt], "lang": lang})
                 self.intent_service.handle_utterance(message)
                 try:
-                    intent_handler.assert_called_once()
+                    intent_failure.assert_called_once_with(message)
+                    intent_failure.reset_mock()
                 except AssertionError as e:
                     raise AssertionError(utt) from e
-                intent_message = intent_handler.call_args[0][0]
-                self.assertIsInstance(intent_message, Message, utt)
-                self.assertEqual(intent_message.msg_type, failure_event, utt)
 
 
 if __name__ == "__main__":

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -30,7 +30,7 @@ import unittest
 import yaml
 
 from os import getenv
-from mock import Mock
+from mock import Mock, patch
 from ovos_utils.messagebus import FakeBus
 from mycroft_bus_client import Message
 from ovos_plugin_manager.skills import load_skill_plugins
@@ -101,7 +101,8 @@ class TestSkillIntentMatching(unittest.TestCase):
                                              value, utt)
                     intent_handler.reset_mock()
 
-    def test_negative_intents(self):
+    @patch('ovos_utils.sound.play_error_sound')
+    def test_negative_intents(self, _):
         intent_handler = Mock()
         failure_event = "complete_intent_failure"
         self.skill.events.add(failure_event, intent_handler)

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -102,7 +102,15 @@ class TestSkillIntentMatching(unittest.TestCase):
                                              value, utt)
                     intent_handler.reset_mock()
 
-    def test_negative_intents(self):
+    @patch("mycroft.skills.intent_services.padatious_service.PadatiousMatcher.match_low")
+    def test_negative_intents(self, pad_low):
+        pad_low.return_value = None
+
+        intent_failure = Mock()
+        self.intent_service.send_complete_intent_failure = intent_failure
+
+        real_pad_low = self.intent_service.padatious_service.match_low = None
+
         last_message = None
 
         def _on_message(msg):
@@ -110,8 +118,6 @@ class TestSkillIntentMatching(unittest.TestCase):
             last_message = msg
 
         self.bus.on("message", _on_message)
-        intent_failure = Mock()
-        self.intent_service.send_complete_intent_failure = intent_failure
         for lang in self.negative_intents.keys():
             for utt in self.negative_intents[lang]:
                 message = Message('test_utterance',

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -44,7 +44,7 @@ class TestSkillIntentMatching(unittest.TestCase):
     test_intents = getenv("INTENT_TEST_FILE")
     with open(test_intents) as f:
         valid_intents = yaml.safe_load(f)
-    negative_intents = valid_intents.pop('NEGATIVE_INTENT_TESTS', dict())
+    negative_intents = valid_intents.pop('unmatched intents', dict())
     from mycroft.skills.intent_service import IntentService
     bus = FakeBus()
     intent_service = IntentService(bus)
@@ -57,6 +57,8 @@ class TestSkillIntentMatching(unittest.TestCase):
 
     def test_intents(self):
         for lang in self.valid_intents.keys():
+            self.assertIsInstance(lang.split('-')[0], str)
+            self.assertIsInstance(lang.split('-')[1], str)
             for intent, examples in self.valid_intents[lang].items():
                 intent_event = f'{self.test_skill_id}:{intent}'
                 self.skill.events.remove(intent_event)

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -34,6 +34,7 @@ from mock import Mock, patch
 from ovos_utils.messagebus import FakeBus
 from mycroft_bus_client import Message
 from ovos_plugin_manager.skills import load_skill_plugins
+from ovos_utils.log import LOG
 
 
 class TestSkillIntentMatching(unittest.TestCase):
@@ -120,7 +121,8 @@ class TestSkillIntentMatching(unittest.TestCase):
                     intent_failure.assert_called_once_with(message)
                     intent_failure.reset_mock()
                 except AssertionError as e:
-                    raise AssertionError(last_message) from e
+                    LOG.error(last_message)
+                    raise AssertionError(utt) from e
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
Add negative intent tests to ensure an utterance does NOT match any skill intent. For example, one might check that "what is my physical address" doesn't match the IP intent.

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Tested with [alerts skill](https://github.com/NeonGeckoCom/skill-alerts/pull/94) and [about skill](https://github.com/NeonGeckoCom/skill-about/pull/73)