### PR TITLE
Unmatched Intent Test Configuration

### DIFF
--- a/.github/workflows/skill_test_installation.yml
+++ b/.github/workflows/skill_test_installation.yml
@@ -27,6 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
         run: |
+          sudo apt update
           sudo apt install -y gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev
           pip install --upgrade pip
           pip install pytest mock ovos-skills-manager

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -28,6 +28,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
         run: |
+          sudo apt update
           sudo apt install -y gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev
           pip install --upgrade pip
           pip install pytest mock ovos-core[skills] action/skill/

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -60,6 +60,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
         run: |
+          sudo apt update
           sudo apt install -y gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev
           pip install --upgrade pip
           pip install pytest mock git+https://github.com/NeonGeckoCom/NeonCore#egg=neon_core action/skill/

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -52,8 +52,6 @@ jobs:
         with:
           repository: NeonGeckoCom/.github
           path: action/github/
-          ref: FEAT_ConfigurableNegativeTests
-          # TODO: Remove above ref
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -51,6 +51,8 @@ jobs:
         with:
           repository: NeonGeckoCom/.github
           path: action/github/
+          ref: FEAT_ConfigurableNegativeTests
+          # TODO: Remove above ref
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/skill_test_resources.yml
+++ b/.github/workflows/skill_test_resources.yml
@@ -25,6 +25,7 @@ jobs:
           python-version: "3.10"
       - name: Install Dependencies
         run: |
+          sudo apt update
           sudo apt install -y gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev
           pip install --upgrade pip
           pip install pytest mock ovos-core[skills] action/skill/

--- a/.github/workflows/skill_tests.yml
+++ b/.github/workflows/skill_tests.yml
@@ -17,6 +17,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
         run: |
+          sudo apt update
           sudo apt install -y gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev
           pip install --upgrade pip
           pip install pytest mock git+https://github.com/NeonGeckoCom/NeonCore#egg=neon_core

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -48,14 +48,17 @@ class MockPadatiousMatcher(PadatiousMatcher):
 
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)
+        LOG.debug("Creating test Padatious Matcher")
 
     def match_medium(self, utterances, lang=None, __=None):
         if not self.include_med:
+            LOG.info(f"Skipping medium confidence check for {utterances}")
             return None
         PadatiousMatcher.match_medium(self, utterances, lang=lang)
 
     def match_low(self, utterances, lang=None, __=None):
         if not self.include_low:
+            LOG.info(f"Skipping low confidence check for {utterances}")
             return None
         PadatiousMatcher.match_low(self, utterances, lang=lang)
 

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -135,7 +135,7 @@ class TestSkillIntentMatching(unittest.TestCase):
                                              value, utt)
                     intent_handler.reset_mock()
 
-    @patch("mycroft.skills.intent_services.padatious_service.PadatiousMatcher",
+    @patch("mycroft.skills.intent_service.PadatiousMatcher",
            new=MockPadatiousMatcher)
     def test_negative_intents(self):
         test_config = self.negative_intents.pop('config', None)

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -47,7 +47,7 @@ class MockPadatiousMatcher(PadatiousMatcher):
     include_low = False
 
     def __init__(self, *args, **kwargs):
-        super().__init__(self, *args, **kwargs)
+        PadatiousMatcher.__init__(self, *args, **kwargs)
         LOG.debug("Creating test Padatious Matcher")
 
     def match_medium(self, utterances, lang=None, __=None):

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -134,7 +134,7 @@ class TestSkillIntentMatching(unittest.TestCase):
 
     @patch("mycroft.skills.intent_services.padatious_service.PadatiousMatcher",
            new=MockPadatiousMatcher)
-    def test_negative_intents(self, _):
+    def test_negative_intents(self):
         test_config = self.negative_intents.pop('config', None)
         if test_config:
             MockPadatiousMatcher.include_med = test_config.get('include_med',


### PR DESCRIPTION
# Description
Adds configuration options to negative intent tests to specify allowing medium/low confidence Padatious intents. In normal use, CommonQuery would handle requests before medium confidence and other fallbacks would handle requests before low confidence.
Includes `apt update` fix for skill test actions
Updates test logging to include DEBUG logs

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Addressing test failures https://github.com/NeonGeckoCom/skill-stock/pull/35