### PR TITLE
Update changelog to include latest release and not just "unreleased"

### DIFF
--- a/.github/workflows/propose_dated_release.yml
+++ b/.github/workflows/propose_dated_release.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           output: ${{ inputs.changelog_file }}
-          unreleasedLabel: ${{ needs.bump_version.outputs.version }}
+          futureRelease: ${{needs.bump_version.outputs.version}}
       - name: Push Changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/propose_semver_release.yml
+++ b/.github/workflows/propose_semver_release.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           output: action/package/${{ inputs.changelog_file }}
-          unreleasedLabel: ${{ needs.bump_version.outputs.version }}
+          futureRelease: ${{needs.bump_version.outputs.version}}
       - name: Push Changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -85,6 +85,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           output: action/package/${{ inputs.changelog_file }}
+          futureRelease: ${{needs.bump_version.outputs.version}}
       - name: Push Changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
# Description
Use `futureRelease` tag in changelogs to properly link generated GH tags/releases

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Tested: https://github.com/NeonDaniel/neon-skill-utils/actions/runs/4694537617