### PR TITLE
Add changelog_max_issues param to limit changelog contents

### DIFF
--- a/.github/workflows/propose_dated_release.yml
+++ b/.github/workflows/propose_dated_release.yml
@@ -14,6 +14,9 @@ on:
       changelog_file:
         type: string
         default: "CHANGELOG.md"
+      changelog_max_issues:
+        type: number
+        default: 50
       branch:
         type: string
         default: "dev"
@@ -73,6 +76,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           output: ${{ inputs.changelog_file }}
           futureRelease: ${{needs.bump_version.outputs.version}}
+          maxIssues: ${{ inputs.changelog_max_issues }}
       - name: Push Changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/propose_semver_release.yml
+++ b/.github/workflows/propose_semver_release.yml
@@ -16,6 +16,9 @@ on:
       changelog_file:
         type: string
         default: "CHANGELOG.md"
+      changelog_max_issues:
+        type: number
+        default: 50
       branch:
         type: string
         default: "dev"
@@ -75,6 +78,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           output: action/package/${{ inputs.changelog_file }}
           futureRelease: ${{needs.bump_version.outputs.version}}
+          maxIssues: ${{ inputs.changelog_max_issues }}
       - name: Push Changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -26,6 +26,9 @@ on:
       changelog_file:
         type: string
         default: "CHANGELOG.md"
+      changelog_max_issues:
+        type: number
+        default: 50
     outputs:
       version:
         description: Updated Alpha version
@@ -86,6 +89,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           output: action/package/${{ inputs.changelog_file }}
           futureRelease: ${{needs.bump_version.outputs.version}}
+          maxIssues: ${{ inputs.changelog_max_issues }}
       - name: Push Changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
# Description
Pass maxIssues to Changelog action to limit changelog size

# Issues
Noticed in [long-running automation in NeonCore](https://github.com/NeonGeckoCom/NeonCore/actions/runs/4694615607/jobs/8322944681)
Fix taken from [ovos-core automation](https://github.com/OpenVoiceOS/ovos-core/blob/dev/.github/workflows/publish_alpha.yml)

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->