### PR TITLE
Add `sinceTag` to changelog generation

### DIFF
--- a/.github/workflows/propose_dated_release.yml
+++ b/.github/workflows/propose_dated_release.yml
@@ -74,7 +74,7 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           repository: ${{ github.repository }}
-          excludes: draft, prerelease
+          excludes: draft,prerelease
       - name: Generate Changelog
         id: changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3

--- a/.github/workflows/propose_dated_release.yml
+++ b/.github/workflows/propose_dated_release.yml
@@ -74,7 +74,7 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           repository: ${{ github.repository }}
-          excludes: draft
+          excludes: draft, prerelease
       - name: Generate Changelog
         id: changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3

--- a/.github/workflows/propose_dated_release.yml
+++ b/.github/workflows/propose_dated_release.yml
@@ -69,6 +69,12 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
           path: action/package/
+      - name: Check Latest Release
+        id: latest_release
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: ${{ github.repository }}
+          excludes: draft
       - name: Generate Changelog
         id: changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3
@@ -77,6 +83,7 @@ jobs:
           output: ${{ inputs.changelog_file }}
           futureRelease: ${{needs.bump_version.outputs.version}}
           maxIssues: ${{ inputs.changelog_max_issues }}
+          sinceTag: ${{ steps.latest_release.outputs.release }}
       - name: Push Changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/propose_semver_release.yml
+++ b/.github/workflows/propose_semver_release.yml
@@ -89,6 +89,12 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
           path: action/package/
+      - name: Check Latest Release
+        id: latest_release
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: ${{ github.repository }}
+          excludes: draft
       - name: Generate Changelog
         id: changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3
@@ -97,6 +103,7 @@ jobs:
           output: action/package/${{ inputs.changelog_file }}
           futureRelease: ${{needs.bump_version.outputs.version}}
           maxIssues: ${{ inputs.changelog_max_issues }}
+          sinceTag: ${{ steps.latest_release.outputs.release }}
       - name: Push Changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/propose_semver_release.yml
+++ b/.github/workflows/propose_semver_release.yml
@@ -94,7 +94,7 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           repository: ${{ github.repository }}
-          excludes: draft
+          excludes: draft, prerelease
       - name: Generate Changelog
         id: changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3

--- a/.github/workflows/propose_semver_release.yml
+++ b/.github/workflows/propose_semver_release.yml
@@ -94,7 +94,7 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           repository: ${{ github.repository }}
-          excludes: draft, prerelease
+          excludes: draft,prerelease
       - name: Generate Changelog
         id: changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -87,7 +87,7 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           repository: ${{ github.repository }}
-          excludes: draft, prerelease
+          excludes: draft,prerelease
       - name: Generate Changelog
         id: changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -94,6 +94,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           output: action/package/${{ inputs.changelog_file }}
+          futureRelease: ${{needs.bump_version.outputs.version}}
+          maxIssues: ${{ inputs.changelog_max_issues }}
           sinceTag: ${{ steps.latest_release.outputs.release }}
       - name: Push Changelog
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -82,14 +82,19 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
           path: action/package/
+      - name: Check Latest Release
+        id: latest_release
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: ${{ github.repository }}
+          excludes: draft
       - name: Generate Changelog
         id: changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           output: action/package/${{ inputs.changelog_file }}
-          futureRelease: ${{needs.bump_version.outputs.version}}
-          maxIssues: ${{ inputs.changelog_max_issues }}
+          sinceTag: ${{ steps.latest_release.outputs.release }}
       - name: Push Changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -87,7 +87,7 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           repository: ${{ github.repository }}
-          excludes: draft
+          excludes: draft, prerelease
       - name: Generate Changelog
         id: changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3


### PR DESCRIPTION
# Description
Updates changelog action to include changes since the last release

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Validated with neon_utils https://github.com/NeonDaniel/neon-skill-utils/actions/runs/4726379140/jobs/8385896423
This doesn't actually prevent github_changelog_generator from fetching a repo's entire history, so it will not solve any rate limiting errors (noted in [this issue](https://github.com/github-changelog-generator/github-changelog-generator/issues/993) as well as others in that project)