### PR TITLE
Fix multiline alpha version handling

### DIFF
--- a/scripts/multiline_semantic_version_bump.py
+++ b/scripts/multiline_semantic_version_bump.py
@@ -57,12 +57,15 @@ def bump_version(version_file: str, version_spec: str):
         if alpha == 0:
             build += 1
         alpha += 1
+        was_alpha = False  # Just for editor warnings, this won't be referenced
     else:
+        was_alpha = alpha != 0
         alpha = 0
 
     # Stable Release
     if version_spec == "build":
-        build += 1
+        if not was_alpha:
+            build += 1
     elif version_spec == "minor":
         build = 0
         minor += 1

--- a/scripts/multiline_semantic_version_bump.py
+++ b/scripts/multiline_semantic_version_bump.py
@@ -55,7 +55,7 @@ def bump_version(version_file: str, version_spec: str):
     # Alpha Release
     if version_spec == "alpha":
         if alpha == 0:
-            minor += 1
+            build += 1
         alpha += 1
     else:
         alpha = 0


### PR DESCRIPTION
# Description
Fix typo in multiline_semantic_version_bump.py in releasing next alpha version

# Issues
Fixes bug introduced in #32 
Issue discovered in https://github.com/OpenVoiceOS/ovos-utils/actions/runs/4728398209

# Other Notes
Tested: https://github.com/NeonDaniel/ovos_utils/actions
0.0.32 -> (alpha) 0.0.33a1 -> (minor) 0.1.0 -> (alpha) 0.1.1a1 -> (build) 0.1.1 -> (major) 1.0.0