### PR TITLE
Continue changelog generation when no prior release exists

### DIFF
--- a/.github/workflows/propose_dated_release.yml
+++ b/.github/workflows/propose_dated_release.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           repository: ${{ github.repository }}
           excludes: draft,prerelease
+        continue-on-error: true
       - name: Generate Changelog
         id: changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3

--- a/.github/workflows/propose_semver_release.yml
+++ b/.github/workflows/propose_semver_release.yml
@@ -95,6 +95,7 @@ jobs:
         with:
           repository: ${{ github.repository }}
           excludes: draft,prerelease
+        continue-on-error: true
       - name: Generate Changelog
         id: changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -88,6 +88,7 @@ jobs:
         with:
           repository: ${{ github.repository }}
           excludes: draft,prerelease
+        continue-on-error: true
       - name: Generate Changelog
         id: changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3


### PR DESCRIPTION
# Description
Previously automation would fail if no previous release exists to generate a changelog from. This changes that behavior to allow changelog generation prior to the first stable release of a package

# Issues
https://github.com/OpenVoiceOS/ovos-bus-client/actions/runs/4737002812/jobs/8409277357

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->