### PR TITLE
Update license tests to read exclusions from inputs

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -5,7 +5,12 @@ on:
       package-extras:
         required: false
         type: string
-
+      packages-exclude:
+        type: string
+        default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct).*'
+      licenses-exclude:
+        type: string
+        default: '^(Mozilla|NeonAI License v1.0).*$'
 jobs:
   license_tests:
     timeout-minutes: 15
@@ -40,8 +45,8 @@ jobs:
           requirements: 'requirements-all.txt'
           fail: 'Copyleft,Other,Error'
           fails-only: true
-          exclude: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct).*'
-          exclude-license: '^(Mozilla|NeonAI License v1.0).*$'
+          exclude: ${{ inputs.packages-exclude }}
+          exclude-license: ${{ inputs.licenses-exclude }}
       - name: Print report
         if: ${{ always() }}
         run: echo "${{ steps.license_check_report.outputs.report }}"


### PR DESCRIPTION
# Description
Update shared license tests to accept excluded packages and licenses as inputs

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Validated https://github.com/NeonGeckoCom/neon_metrics_service/pull/18