### PR TITLE
Enable non-default action runners

### DIFF
--- a/.github/workflows/docker_build_tests.yml
+++ b/.github/workflows/docker_build_tests.yml
@@ -1,10 +1,14 @@
 name: Docker Build Tests
 on:
   workflow_call:
+    inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
 jobs:
   docker_build_tests:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     steps:
       - uses: actions/checkout@v2
       - name: Build image

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -2,6 +2,9 @@ name: Run License Tests
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
       package-extras:
         required: false
         type: string
@@ -14,7 +17,7 @@ on:
 jobs:
   license_tests:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/.github/workflows/propose_dated_release.yml
+++ b/.github/workflows/propose_dated_release.yml
@@ -2,6 +2,9 @@ name: Propose Dated Stable Release
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
       version_file:
         type: string
         default: "version.py"
@@ -29,7 +32,7 @@ on:
         value: action/package/${{jobs.update_changelog.outputs.changelog}}
 jobs:
   bump_version:
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -59,7 +62,7 @@ jobs:
           repository: action/package/
   update_changelog:
     needs: bump_version
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     if: ${{ inputs.update_changelog }}
     outputs:
       changelog: ${{ steps.changelog.outputs.changelog }}

--- a/.github/workflows/propose_semver_release.yml
+++ b/.github/workflows/propose_semver_release.yml
@@ -2,6 +2,9 @@ name: Propose Stable Release
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
       version_file:
         type: string
         default: "version.py"
@@ -44,7 +47,7 @@ on:
 
 jobs:
   bump_version:
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -79,7 +82,7 @@ jobs:
           repository: action/package/
   update_changelog:
     needs: bump_version
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     if: ${{ inputs.update_changelog }}
     outputs:
       changelog: ${{ steps.changelog.outputs.changelog }}

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -2,6 +2,9 @@ name: Publish Alpha Build
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
       version_file:
         type: string
         default: "version.py"
@@ -38,7 +41,7 @@ on:
         value: ${{jobs.update_changelog.outputs.changelog}}
 jobs:
   bump_version:
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -72,7 +75,7 @@ jobs:
           repository: action/package/
   update_changelog:
     needs: bump_version
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     if: ${{ inputs.update_changelog }}
     outputs:
       changelog: ${{ steps.changelog.outputs.changelog }}
@@ -108,7 +111,7 @@ jobs:
     needs:
       - update_changelog
       - bump_version
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -141,7 +144,7 @@ jobs:
       - update_changelog
       - bump_version
     if: ${{ always() && inputs.publish_prerelease }}
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -2,6 +2,9 @@ name: Publish Docker Containers
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
       base_tag:
         type: string
         required: false
@@ -21,7 +24,7 @@ env:
 
 jobs:
   build_and_publish_docker:
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     outputs:
       version: ${{ steps.version.version }}
     permissions:

--- a/.github/workflows/publish_stable_release.yml
+++ b/.github/workflows/publish_stable_release.yml
@@ -1,10 +1,14 @@
 name: Publish Stable Build
 on:
   workflow_call:
+    inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
 
 jobs:
   tag_release:
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     steps:
       - uses: actions/checkout@v2
       - name: Get Version
@@ -16,7 +20,7 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           tag: ${{env.VERSION}}
   build_and_publish_pypi:
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/.github/workflows/pull_master.yml
+++ b/.github/workflows/pull_master.yml
@@ -2,6 +2,9 @@ name: Pull to Master
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
       pr_reviewer:
         required: false
         type: string
@@ -21,7 +24,7 @@ on:
 
 jobs:
   pull_changes:
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     steps:
       - uses: actions/checkout@v2
       - name: pull-request-action

--- a/.github/workflows/python_build_tests.yml
+++ b/.github/workflows/python_build_tests.yml
@@ -2,6 +2,9 @@ name: Python Build Tests
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
       python_version:
         required: false
         type: string
@@ -17,7 +20,7 @@ on:
 jobs:
   py_build_tests:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     steps:
       - uses: actions/checkout@v2
       - name: Set up python ${{ inputs.python_version }}

--- a/.github/workflows/skill_test_installation.yml
+++ b/.github/workflows/skill_test_installation.yml
@@ -2,6 +2,9 @@ name: Skill Installation Tests
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
       branch:
         type: string
         default: ${{ github.ref }}
@@ -10,7 +13,7 @@ on:
         default: ${{ github.repository }}
 jobs:
   test_osm_install:
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     timeout-minutes: 5
     strategy:
       matrix:

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -2,6 +2,9 @@ name: Skill Unit Tests
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
       intent_file:
         type: string
         default: test/test_intents.yaml
@@ -10,7 +13,7 @@ on:
         default: 10
 jobs:
   test_intents_ovos:
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     timeout-minutes: ${{inputs.timeout}}
     strategy:
       matrix:
@@ -40,7 +43,7 @@ jobs:
           export INTENT_TEST_FILE="action/skill/${{inputs.intent_file}}"
           pytest action/github/test/test_skill_intents.py
   test_intents_neon:
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     timeout-minutes: ${{inputs.timeout}}
     strategy:
       matrix:

--- a/.github/workflows/skill_test_resources.yml
+++ b/.github/workflows/skill_test_resources.yml
@@ -2,12 +2,15 @@ name: Skill Unit Tests
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
       resource_file:
         type: string
         default: test/test_resources.yaml
 jobs:
   test_resources:
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     timeout-minutes: 5
     steps:
       - name: Checkout Repository

--- a/.github/workflows/skill_tests.yml
+++ b/.github/workflows/skill_tests.yml
@@ -1,13 +1,16 @@
 name: Skill Unit Tests
 on:
   workflow_call:
-
+    inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
 jobs:
   neon_core:
     strategy:
       matrix:
         python-version: [ 3.7, 3.8, 3.9, '3.10' ]
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +32,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ 3.8 ]
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/skill_update_json_spec.yml
+++ b/.github/workflows/skill_update_json_spec.yml
@@ -1,10 +1,14 @@
 name: Update skill.json
 on:
   workflow_call:
+    inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
 
 jobs:
   update_skill_json:
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     timeout-minutes: 15
     steps:
       - name: Checkout Repository

--- a/.github/workflows/skill_update_meta_repo.yml
+++ b/.github/workflows/skill_update_meta_repo.yml
@@ -2,10 +2,14 @@
 name: Update neon_skills
 on:
   workflow_call:
+    inputs:
+      runner:
+        type: string
+        default: "ubuntu-latest"
 
 jobs:
   push_skill_json:
-    runs-on: ubuntu-latest
+    runs-on: ${{inputs.runner}}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# Description
Update workflows to allow callers to specify `runner`, i.e. for self-hosted runners
This initially is implemented to work around issues building the neon-speech Docker container

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Validated https://github.com/NeonGeckoCom/neon_speech/pull/149