### PR TITLE
Make OSM tests optional

### DIFF
--- a/.github/workflows/skill_test_installation.yml
+++ b/.github/workflows/skill_test_installation.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           repository: NeonGeckoCom/.github
           path: action/github/
+          ref: FIX_AllowFailingOSMTests
+          # TODO: Remove `ref` spec
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/skill_test_installation.yml
+++ b/.github/workflows/skill_test_installation.yml
@@ -11,10 +11,14 @@ on:
       repository:
         type: string
         default: ${{ github.repository }}
+      test_osm:
+        type: boolean
+        default: true
 jobs:
   test_osm_install:
     runs-on: ${{inputs.runner}}
     timeout-minutes: 5
+    if: ${{ inputs.test_osm }}
     strategy:
       matrix:
         python-version: [ 3.7, 3.8, 3.9, '3.10' ]
@@ -24,8 +28,6 @@ jobs:
         with:
           repository: NeonGeckoCom/.github
           path: action/github/
-          ref: FIX_AllowFailingOSMTests
-          # TODO: Remove `ref` spec
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/skill_test_installation.yml
+++ b/.github/workflows/skill_test_installation.yml
@@ -34,7 +34,7 @@ jobs:
           sudo apt install -y gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev
           pip install --upgrade pip
           pip install pytest mock ovos-skills-manager
-      - name: Test Skill Intents
+      - name: Test OSM Installation
         run: |
           export TEST_REPO=${{inputs.repository}}
           export TEST_BRANCH=${{inputs.branch}}

--- a/test/test_skill_osm_install.py
+++ b/test/test_skill_osm_install.py
@@ -27,8 +27,8 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
+import pytest.mock
 
-from pytest.mark import xfail
 from os import environ
 from os.path import exists, isdir, isfile, join
 from shutil import rmtree
@@ -38,7 +38,7 @@ from ovos_skills_manager import SkillEntry
 
 class TestOSM(unittest.TestCase):
     # TODO: Remove with next OSM release or deprecate test
-    @xfail(reason="OSM Dependency Bug with `requests`")
+    @pytest.mark.xfail(reason="OSM Dependency Bug with `requests`")
     def test_osm_install(self):
         branch = environ.get("TEST_BRANCH")
         install_url = f"https://github.com/{environ.get('TEST_REPO')}@{branch}"

--- a/test/test_skill_osm_install.py
+++ b/test/test_skill_osm_install.py
@@ -27,7 +27,6 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
-import pytest
 
 from os import environ
 from os.path import exists, isdir, isfile, join
@@ -37,8 +36,6 @@ from ovos_skills_manager import SkillEntry
 
 
 class TestOSM(unittest.TestCase):
-    # TODO: Remove with next OSM release or deprecate test
-    @pytest.mark.xfail(reason="OSM Dependency Bug with `requests`")
     def test_osm_install(self):
         branch = environ.get("TEST_BRANCH")
         install_url = f"https://github.com/{environ.get('TEST_REPO')}@{branch}"

--- a/test/test_skill_osm_install.py
+++ b/test/test_skill_osm_install.py
@@ -27,7 +27,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
-import pytest.mock
+import pytest.mark
 
 from os import environ
 from os.path import exists, isdir, isfile, join
@@ -38,7 +38,7 @@ from ovos_skills_manager import SkillEntry
 
 class TestOSM(unittest.TestCase):
     # TODO: Remove with next OSM release or deprecate test
-    @pytest.mark.skip(reason="OSM Dependency Bug with `requests`")
+    @pytest.mark.xfail(reason="OSM Dependency Bug with `requests`")
     def test_osm_install(self):
         branch = environ.get("TEST_BRANCH")
         install_url = f"https://github.com/{environ.get('TEST_REPO')}@{branch}"

--- a/test/test_skill_osm_install.py
+++ b/test/test_skill_osm_install.py
@@ -28,6 +28,7 @@
 
 import unittest
 
+from pytest.mark import xfail
 from os import environ
 from os.path import exists, isdir, isfile, join
 from shutil import rmtree
@@ -36,6 +37,8 @@ from ovos_skills_manager import SkillEntry
 
 
 class TestOSM(unittest.TestCase):
+    # TODO: Remove with next OSM release or deprecate test
+    @xfail(reason="OSM Dependency Bug with `requests`")
     def test_osm_install(self):
         branch = environ.get("TEST_BRANCH")
         install_url = f"https://github.com/{environ.get('TEST_REPO')}@{branch}"

--- a/test/test_skill_osm_install.py
+++ b/test/test_skill_osm_install.py
@@ -38,7 +38,7 @@ from ovos_skills_manager import SkillEntry
 
 class TestOSM(unittest.TestCase):
     # TODO: Remove with next OSM release or deprecate test
-    @pytest.mark.xfail(reason="OSM Dependency Bug with `requests`")
+    @pytest.mark.skip(reason="OSM Dependency Bug with `requests`")
     def test_osm_install(self):
         branch = environ.get("TEST_BRANCH")
         install_url = f"https://github.com/{environ.get('TEST_REPO')}@{branch}"

--- a/test/test_skill_osm_install.py
+++ b/test/test_skill_osm_install.py
@@ -27,7 +27,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
-import pytest.mark
+import pytest
 
 from os import environ
 from os.path import exists, isdir, isfile, join


### PR DESCRIPTION
# Description
OSM tests are failing due to an upstream dependency bug and OSM/git installation is not recommended for most skills at this point anyways. 
This defaults to previous behavior that includes OSM tests, but allows for skipping OSM tests so future installation tests are not necessarily skipped

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Validated https://github.com/NeonGeckoCom/skill-speak/actions/runs/4931628344/jobs/8813856059?pr=24