### PR TITLE
Better Padatious/Padacioso Test Specificaiton

### DIFF
--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -11,6 +11,9 @@ on:
       timeout:
         type: number
         default: 10
+      test_padatious:
+        type: boolean
+        default: False
 jobs:
   test_intents_ovos:
     runs-on: ${{inputs.runner}}
@@ -37,11 +40,16 @@ jobs:
           sudo apt update
           sudo apt install -y gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev
           pip install --upgrade pip
-          pip install pytest mock ovos-core[skills] action/skill/
-      - name: Test Skill Intents
+          pip install pytest mock ovos-core[skills-lgpl] action/skill/
+      - name: Test Skill Intents Padacioso
         run: |
           export INTENT_TEST_FILE="action/skill/${{inputs.intent_file}}"
-          pytest action/github/test/test_skill_intents.py
+          pytest action/github/test/test_skill_intents.py padacioso
+      - name: Test Skill Intents Padatious
+        if: ${{ inputs.test_padatious }}
+        run: |
+          export INTENT_TEST_FILE="action/skill/${{inputs.intent_file}}"
+          pytest action/github/test/test_skill_intents.py padatious
   test_intents_neon:
     runs-on: ${{inputs.runner}}
     timeout-minutes: ${{inputs.timeout}}
@@ -68,7 +76,12 @@ jobs:
           sudo apt install -y gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev
           pip install --upgrade pip
           pip install pytest mock git+https://github.com/NeonGeckoCom/NeonCore#egg=neon_core action/skill/
-      - name: Test Skill Intents
+      - name: Test Skill Intents Padacioso
         run: |
           export INTENT_TEST_FILE="action/skill/${{inputs.intent_file}}"
-          pytest action/github/test/test_skill_intents.py
+          pytest action/github/test/test_skill_intents.py padacioso
+      - name: Test Skill Intents Padatious
+        if: ${{ inputs.test_padatious }}
+        run: |
+          export INTENT_TEST_FILE="action/skill/${{inputs.intent_file}}"
+          pytest action/github/test/test_skill_intents.py padatious

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -45,7 +45,7 @@ jobs:
           sudo apt update
           sudo apt install -y gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev
           pip install --upgrade pip
-          pip install pytest mock ovos-core[skills,skills-lgpl] action/skill/
+          pip install pytest mock ovos-core[skills,skills_lgpl] action/skill/
       - name: Test Skill Intents Padacioso
         if: ${{ inputs.test_padacioso }}
         run: |

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           repository: NeonGeckoCom/.github
           path: action/github/
+          ref: FEAT_Padacioso
+          # TODO: Update to default
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt update
           sudo apt install -y gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev
           pip install --upgrade pip
-          pip install pytest mock ovos-core[skills-lgpl] action/skill/
+          pip install pytest mock ovos-core[skills,skills-lgpl] action/skill/
       - name: Test Skill Intents Padacioso
         run: |
           export INTENT_ENGINE="padacioso"

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -34,8 +34,6 @@ jobs:
         with:
           repository: NeonGeckoCom/.github
           path: action/github/
-          ref: FEAT_Padacioso
-          # TODO: Update to default
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -45,13 +45,15 @@ jobs:
           pip install pytest mock ovos-core[skills-lgpl] action/skill/
       - name: Test Skill Intents Padacioso
         run: |
+          export INTENT_ENGINE="padacioso"
           export INTENT_TEST_FILE="action/skill/${{inputs.intent_file}}"
-          pytest action/github/test/test_skill_intents.py padacioso
+          pytest action/github/test/test_skill_intents.py
       - name: Test Skill Intents Padatious
         if: ${{ inputs.test_padatious }}
         run: |
+          export INTENT_ENGINE="padatious"
           export INTENT_TEST_FILE="action/skill/${{inputs.intent_file}}"
-          pytest action/github/test/test_skill_intents.py padatious
+          pytest action/github/test/test_skill_intents.py
   test_intents_neon:
     runs-on: ${{inputs.runner}}
     timeout-minutes: ${{inputs.timeout}}
@@ -80,10 +82,12 @@ jobs:
           pip install pytest mock git+https://github.com/NeonGeckoCom/NeonCore#egg=neon_core action/skill/
       - name: Test Skill Intents Padacioso
         run: |
+          export INTENT_ENGINE="padacioso"
           export INTENT_TEST_FILE="action/skill/${{inputs.intent_file}}"
-          pytest action/github/test/test_skill_intents.py padacioso
+          pytest action/github/test/test_skill_intents.py
       - name: Test Skill Intents Padatious
         if: ${{ inputs.test_padatious }}
         run: |
+          export INTENT_ENGINE="padatious"
           export INTENT_TEST_FILE="action/skill/${{inputs.intent_file}}"
-          pytest action/github/test/test_skill_intents.py padatious
+          pytest action/github/test/test_skill_intents.py

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -14,6 +14,9 @@ on:
       test_padatious:
         type: boolean
         default: False
+      test_padacioso:
+        type: boolean
+        default: True
 jobs:
   test_intents_ovos:
     runs-on: ${{inputs.runner}}
@@ -44,6 +47,7 @@ jobs:
           pip install --upgrade pip
           pip install pytest mock ovos-core[skills,skills-lgpl] action/skill/
       - name: Test Skill Intents Padacioso
+        if: ${{ inputs.test_padacioso }}
         run: |
           export INTENT_ENGINE="padacioso"
           export INTENT_TEST_FILE="action/skill/${{inputs.intent_file}}"
@@ -81,6 +85,7 @@ jobs:
           pip install --upgrade pip
           pip install pytest mock git+https://github.com/NeonGeckoCom/NeonCore#egg=neon_core action/skill/
       - name: Test Skill Intents Padacioso
+        if: ${{ inputs.test_padacioso }}
         run: |
           export INTENT_ENGINE="padacioso"
           export INTENT_TEST_FILE="action/skill/${{inputs.intent_file}}"

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -10,7 +10,7 @@ on:
         default: test/test_intents.yaml
       timeout:
         type: number
-        default: 10
+        default: 15
       test_padatious:
         type: boolean
         default: False

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -33,16 +33,12 @@ import logging
 from os import getenv
 from mock import Mock, patch
 from mycroft_bus_client import Message
-
-regex_only = getenv("INTENT_ENGINE") == "padacioso"
-from ovos_config.config import update_mycroft_config
-update_mycroft_config({"padatious": {"regex_only": regex_only}})
-
 from ovos_utils.messagebus import FakeBus
 from ovos_plugin_manager.skills import load_skill_plugins
 from ovos_utils.log import LOG
 from mycroft.skills.intent_services.padatious_service import PadatiousMatcher
 
+regex_only = getenv("INTENT_ENGINE") == "padacioso"
 LOG.level = logging.DEBUG
 
 
@@ -80,6 +76,7 @@ class TestSkillIntentMatching(unittest.TestCase):
     from mycroft.skills.intent_service import IntentService
     bus = FakeBus()
     intent_service = IntentService(bus)
+    intent_service.padatious_service.padatious_config['regex_only'] = regex_only
     assert intent_service.padatious_service.is_regex_only == regex_only
     test_skill_id = 'test_skill.test'
     last_message = None

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -37,10 +37,13 @@ from mycroft_bus_client import Message
 from ovos_plugin_manager.skills import load_skill_plugins
 from ovos_utils.log import LOG
 
-from mycroft.skills.intent_services.padatious_service import PadatiousMatcher
 
 LOG.level = logging.DEBUG
 regex_only = getenv("INTENT_ENGINE") == "padacioso"
+from ovos_config.config import update_mycroft_config
+update_mycroft_config({"padatious": {"regex_only": regex_only}})
+
+from mycroft.skills.intent_services.padatious_service import PadatiousMatcher
 
 
 class MockPadatiousMatcher(PadatiousMatcher):
@@ -207,6 +210,4 @@ class TestSkillIntentMatching(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    from ovos_config.config import update_mycroft_config
-    update_mycroft_config({"padatious": {"regex_only": regex_only}})
     unittest.main()

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -30,7 +30,6 @@ import unittest
 import yaml
 import logging
 
-from sys import argv
 from os import getenv
 from mock import Mock, patch
 from ovos_utils.messagebus import FakeBus
@@ -41,7 +40,7 @@ from ovos_utils.log import LOG
 from mycroft.skills.intent_services.padatious_service import PadatiousMatcher
 
 LOG.level = logging.DEBUG
-regex_only = False
+regex_only = getenv("INTENT_ENGINE") == "padacioso"
 
 
 class MockPadatiousMatcher(PadatiousMatcher):
@@ -208,10 +207,6 @@ class TestSkillIntentMatching(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    global regex_only
-    regex_only = False
-    if argv[1] == "padacioso":
-        regex_only = True
     from ovos_config.config import update_mycroft_config
     update_mycroft_config({"padatious": {"regex_only": regex_only}})
     unittest.main()

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -30,6 +30,7 @@ import unittest
 import yaml
 import logging
 
+from sys import argv
 from os import getenv
 from mock import Mock, patch
 from ovos_utils.messagebus import FakeBus
@@ -40,6 +41,7 @@ from ovos_utils.log import LOG
 from mycroft.skills.intent_services.padatious_service import PadatiousMatcher
 
 LOG.level = logging.DEBUG
+regex_only = False
 
 
 class MockPadatiousMatcher(PadatiousMatcher):
@@ -76,6 +78,7 @@ class TestSkillIntentMatching(unittest.TestCase):
     from mycroft.skills.intent_service import IntentService
     bus = FakeBus()
     intent_service = IntentService(bus)
+    assert intent_service.padatious_service.is_regex_only == regex_only
     test_skill_id = 'test_skill.test'
     last_message = None
 
@@ -205,4 +208,10 @@ class TestSkillIntentMatching(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    global regex_only
+    regex_only = False
+    if argv[1] == "padacioso":
+        regex_only = True
+    from ovos_config.config import update_mycroft_config
+    update_mycroft_config({"padatious": {"regex_only": regex_only}})
     unittest.main()

--- a/test/test_skill_intents.py
+++ b/test/test_skill_intents.py
@@ -32,18 +32,18 @@ import logging
 
 from os import getenv
 from mock import Mock, patch
-from ovos_utils.messagebus import FakeBus
 from mycroft_bus_client import Message
-from ovos_plugin_manager.skills import load_skill_plugins
-from ovos_utils.log import LOG
 
-
-LOG.level = logging.DEBUG
 regex_only = getenv("INTENT_ENGINE") == "padacioso"
 from ovos_config.config import update_mycroft_config
 update_mycroft_config({"padatious": {"regex_only": regex_only}})
 
+from ovos_utils.messagebus import FakeBus
+from ovos_plugin_manager.skills import load_skill_plugins
+from ovos_utils.log import LOG
 from mycroft.skills.intent_services.padatious_service import PadatiousMatcher
+
+LOG.level = logging.DEBUG
 
 
 class MockPadatiousMatcher(PadatiousMatcher):


### PR DESCRIPTION
# Description
Adds options to specifically test against Padatious and Padacioso intent parsers. By default, only Padacioso tests are run as those better represent actionable changes to be made to intents.

Note that Adapt intents are tested in both cases, and if neither Padatios or Padacioso tests are specified then no intent tests will be run. Adapt intents are intended to run in both cases as those intent matches may be affected by any Padatious/Padacioso intents.

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Validated https://github.com/NeonGeckoCom/skill-alerts/actions/runs/4932639106/jobs/8815854509