### PR TITLE
Exclude cattrs 23.1.0 with dependency bug

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,4 @@
 neon-utils~=1.2
 ovos-skills-manager~=0.0
+cattrs != 23.1.0
+# TODO: cattrs patching https://github.com/python-attrs/cattrs/issues/369


### PR DESCRIPTION
# Description
Fix failing skill.json automation by excluding cattrs version with dependency bug

# Issues
https://github.com/python-attrs/cattrs/issues/369

# Other Notes
Tested https://github.com/NeonGeckoCom/skill-user_settings/pull/87