### PR TITLE
Add sdist build to alpha and stable release actions

### DIFF
--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Build Distribution Packages
         run: |
           cd action/package
-          python ${{ inputs.setup_py }} bdist_wheel
+          python ${{ inputs.setup_py }} sdist bdist_wheel
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/publish_stable_release.yml
+++ b/.github/workflows/publish_stable_release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build Distribution Packages
         run: |
-          python setup.py bdist_wheel
+          python setup.py sdist bdist_wheel
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
# Description
Adds `sdist` packaging to alpha and release automation

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Tested [with neon-utils](https://github.com/NeonGeckoCom/neon-utils/pull/461)