### PR TITLE
Add tests for relative paths in setup.py

### DIFF
--- a/.github/workflows/python_build_tests.yml
+++ b/.github/workflows/python_build_tests.yml
@@ -50,10 +50,22 @@ jobs:
         uses: pypa/gh-action-pip-audit@v1.0.7
         with:
           ignore-vulns: ${{ inputs.pipaudit_ignored }}
+  relative_path_build_tests:
+    timeout-minutes: 15
+    runs-on: ${{inputs.runner}}
+    steps:
       - name: Checkout Repository to build_test
         uses: actions/checkout@v2
         with:
           path: build_test
+      - name: Set up python ${{ inputs.python_version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ inputs.python_version }}
+      - name: Install Build Tools
+        run: |
+          python -m pip install build wheel
       - name: Build Distribution Packages
         run: |
           python build_test/setup.py bdist_wheel sdist || echo "::error setup.py:: Are there relative paths in setup.py?"
+          python build_test/setup.py --version

--- a/.github/workflows/python_build_tests.yml
+++ b/.github/workflows/python_build_tests.yml
@@ -52,7 +52,8 @@ jobs:
           ignore-vulns: ${{ inputs.pipaudit_ignored }}
       - name: Checkout Repository to /tmp/package
         uses: actions/checkout@v2
-        path: /tmp/package
+        with:
+          path: /tmp/package
       - name: Build Distribution Packages
         run: |
           python /tmp/package/setup.py bdist_wheel sdist || echo "::error setup.py:: Are there relative paths in setup.py?"

--- a/.github/workflows/python_build_tests.yml
+++ b/.github/workflows/python_build_tests.yml
@@ -20,6 +20,9 @@ on:
       test_pipaudit:
         type: boolean
         default: false
+      test_relative_paths:
+        type: boolean
+        default: true
       pipaudit_ignored:
         type: string
         default: "GHSA-r9hx-vwmv-q579 PYSEC-2022-43012"
@@ -53,6 +56,7 @@ jobs:
   relative_path_tests:
     timeout-minutes: 15
     runs-on: ${{inputs.runner}}
+    if: ${{ inputs.test_relative_paths }}
     steps:
       - name: Checkout Repository to build_test
         uses: actions/checkout@v2

--- a/.github/workflows/python_build_tests.yml
+++ b/.github/workflows/python_build_tests.yml
@@ -50,7 +50,7 @@ jobs:
         uses: pypa/gh-action-pip-audit@v1.0.7
         with:
           ignore-vulns: ${{ inputs.pipaudit_ignored }}
-  relative_path_build_tests:
+  relative_path_tests:
     timeout-minutes: 15
     runs-on: ${{inputs.runner}}
     steps:

--- a/.github/workflows/python_build_tests.yml
+++ b/.github/workflows/python_build_tests.yml
@@ -28,7 +28,8 @@ jobs:
     timeout-minutes: 15
     runs-on: ${{inputs.runner}}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Repository
+        uses: actions/checkout@v2
       - name: Set up python ${{ inputs.python_version }}
         uses: actions/setup-python@v2
         with:
@@ -49,3 +50,9 @@ jobs:
         uses: pypa/gh-action-pip-audit@v1.0.7
         with:
           ignore-vulns: ${{ inputs.pipaudit_ignored }}
+      - name: Checkout Repository to /tmp/package
+        uses: actions/checkout@v2
+        path: /tmp/package
+      - name: Build Distribution Packages
+        run: |
+          python /tmp/package/setup.py bdist_wheel sdist || echo "::error setup.py:: Are there relative paths in setup.py?"

--- a/.github/workflows/python_build_tests.yml
+++ b/.github/workflows/python_build_tests.yml
@@ -50,10 +50,10 @@ jobs:
         uses: pypa/gh-action-pip-audit@v1.0.7
         with:
           ignore-vulns: ${{ inputs.pipaudit_ignored }}
-      - name: Checkout Repository to /tmp/package
+      - name: Checkout Repository to build_test
         uses: actions/checkout@v2
         with:
-          path: /tmp/package
+          path: build_test
       - name: Build Distribution Packages
         run: |
-          python /tmp/package/setup.py bdist_wheel sdist || echo "::error setup.py:: Are there relative paths in setup.py?"
+          python build_test/setup.py bdist_wheel sdist || echo "::error setup.py:: Are there relative paths in setup.py?"

--- a/.github/workflows/python_build_tests.yml
+++ b/.github/workflows/python_build_tests.yml
@@ -72,4 +72,3 @@ jobs:
       - name: Build Distribution Packages
         run: |
           python build_test/setup.py bdist_wheel sdist || echo "::error setup.py:: Are there relative paths in setup.py?"
-          python build_test/setup.py --version


### PR DESCRIPTION
# Description
Adds a second build test to check for any relative file paths in setup.py that will fail in other automations

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
[Failure tested](https://github.com/NeonGeckoCom/neon-tts-plugin-coqui-remote/actions/runs/5348150186/jobs/9697635213)
[Success tested](https://github.com/NeonGeckoCom/neon-tts-plugin-coqui-remote/actions/runs/5348183199/jobs/9697716217)