### PR TITLE
Make python versions configurable per-core in skill test automation

### DIFF
--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: ${{inputs.timeout}}
     strategy:
       matrix:
-        python-version: ${{ fromJSON(github.event.inputs.ovos_versions) }}
+        python-version: ${{ fromJSON(inputs.ovos_versions) }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: ${{inputs.timeout}}
     strategy:
       matrix:
-        python-version: ${{ fromJSON(github.event.inputs.neon_versions) }}
+        python-version: ${{ fromJSON(inputs.neon_versions) }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -17,13 +17,20 @@ on:
       test_padacioso:
         type: boolean
         default: True
+      neon_versions:
+        type: string
+        default: "[ 3.7, 3.8, 3.9, '3.10' ]"
+      ovos_versions:
+        type: string
+        default: "[ 3.8, '3.10' ]"
 jobs:
   test_intents_ovos:
+    if: "${{ inputs.ovos_versions != '' }}"
     runs-on: ${{inputs.runner}}
     timeout-minutes: ${{inputs.timeout}}
     strategy:
       matrix:
-        python-version: [ '3.10' ]
+        python-version: ${{ fromJSON(github.event.inputs.ovos_versions) }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -59,11 +66,12 @@ jobs:
           export INTENT_TEST_FILE="action/skill/${{inputs.intent_file}}"
           pytest action/github/test/test_skill_intents.py
   test_intents_neon:
+    if: "${{ inputs.neon_versions != '' }}"
     runs-on: ${{inputs.runner}}
     timeout-minutes: ${{inputs.timeout}}
     strategy:
       matrix:
-        python-version: [ 3.7, '3.10' ]
+        python-version: ${{ fromJSON(github.event.inputs.neon_versions) }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -83,9 +83,7 @@ jobs:
           sudo apt update
           sudo apt install -y gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev
           pip install --upgrade pip
-          pip install wheel "cython<3.0.0"  # TODO: cython patching https://github.com/yaml/pyyaml/issues/724
-          pip install --no-build-isolation pyyaml~=5.4  # TODO: patching https://github.com/yaml/pyyaml/issues/724
-          pip install pytest mock git+https://github.com/NeonGeckoCom/NeonCore#egg=neon_core action/skill/
+          pip install pytest mock git+https://github.com/NeonGeckoCom/NeonCore@master#egg=neon_core action/skill/
       - name: Test Skill Intents Padacioso
         if: ${{ inputs.test_padacioso }}
         run: |

--- a/.github/workflows/skill_tests.yml
+++ b/.github/workflows/skill_tests.yml
@@ -5,11 +5,18 @@ on:
       runner:
         type: string
         default: "ubuntu-latest"
+    neon_versions:
+      type: string
+      default: "[ 3.7, 3.8, 3.9, '3.10' ]"
+    ovos_versions:
+      type: string
+      default: "[ 3.8, '3.10' ]"
 jobs:
   neon_core:
+    if: "${{ inputs.neon_versions != '' }}"
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
+        python-version: ${{ fromJSON(github.event.inputs.neon_versions) }}
     runs-on: ${{inputs.runner}}
     timeout-minutes: 15
     steps:
@@ -31,9 +38,10 @@ jobs:
         run: |
           pytest test/test_skill.py
   ovos-core:
+    if: "${{ inputs.ovos_versions != '' }}"
     strategy:
       matrix:
-        python-version: [ 3.8 ]
+        python-version: ${{ fromJSON(github.event.inputs.ovos_versions) }}
     runs-on: ${{inputs.runner}}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/skill_tests.yml
+++ b/.github/workflows/skill_tests.yml
@@ -5,12 +5,12 @@ on:
       runner:
         type: string
         default: "ubuntu-latest"
-    neon_versions:
-      type: string
-      default: "[ 3.7, 3.8, 3.9, '3.10' ]"
-    ovos_versions:
-      type: string
-      default: "[ 3.8, '3.10' ]"
+      neon_versions:
+        type: string
+        default: "[ 3.7, 3.8, 3.9, '3.10' ]"
+      ovos_versions:
+        type: string
+        default: "[ 3.8, '3.10' ]"
 jobs:
   neon_core:
     if: "${{ inputs.neon_versions != '' }}"

--- a/.github/workflows/skill_tests.yml
+++ b/.github/workflows/skill_tests.yml
@@ -16,7 +16,7 @@ jobs:
     if: "${{ inputs.neon_versions != '' }}"
     strategy:
       matrix:
-        python-version: ${{ fromJSON(github.event.inputs.neon_versions) }}
+        python-version: ${{ fromJSON(inputs.neon_versions) }}
     runs-on: ${{inputs.runner}}
     timeout-minutes: 15
     steps:
@@ -41,7 +41,7 @@ jobs:
     if: "${{ inputs.ovos_versions != '' }}"
     strategy:
       matrix:
-        python-version: ${{ fromJSON(github.event.inputs.ovos_versions) }}
+        python-version: ${{ fromJSON(inputs.ovos_versions) }}
     runs-on: ${{inputs.runner}}
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
# Description
Adds options to override python versions to test skills against ovos/neon cores (or disable tests for a particular core)
Also updates Neon tests to run against `master` branch
To disable tests for a particular core, pass an empty string and not an empty list

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Backwards-compat validated https://github.com/NeonGeckoCom/skill-support_helper/actions/runs/5894424795/job/15988037070?pr=69
New behavior validated https://github.com/NeonGeckoCom/skill-support_helper/actions/runs/5894603041