### PR TITLE
Allow calling workflow to specify skill entrypoint

### DIFF
--- a/.github/workflows/skill_test_resources.yml
+++ b/.github/workflows/skill_test_resources.yml
@@ -8,6 +8,9 @@ on:
       resource_file:
         type: string
         default: test/test_resources.yaml
+      skill_entrypoint:
+        type: string
+        default: action/skill/
 jobs:
   test_resources:
     runs-on: ${{inputs.runner}}
@@ -38,5 +41,5 @@ jobs:
       - name: Test Skill Resources
         run: |
           export RESOURCE_TEST_FILE="action/skill/${{inputs.resource_file}}"
-          export TEST_SKILL_ENTRYPOINT="action/skill/"
+          export TEST_SKILL_ENTRYPOINT="${{inputs.skill_entrypoint}}"
           pytest action/github/test/test_skill_resources.py


### PR DESCRIPTION
# Description
Previous implementation assumed the skill package exists at the repo root
`skill_entrypoint` can be set to either a skill root directory or entrypoint specified in setup.py

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
https://github.com/NeonGeckoCom/skill-mark2-audio-receiver/pull/18