### PR TITLE
Update Docker Actions and Support `build-args`

### DIFF
--- a/.github/workflows/docker_build_tests.yml
+++ b/.github/workflows/docker_build_tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{inputs.runner}}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build image
         run: docker build .
       - name: Setup Docker Buildx

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -29,10 +29,8 @@ on:
         default: Dockerfile
       build_args:
         type: string
-        default: "[]"
       extra_build_args:
         type: string
-        default: "[]"
 
 env:
   REGISTRY: ${{ inputs.registry }}
@@ -91,7 +89,8 @@ jobs:
           target: ${{ inputs.base_tag }}
           platforms: ${{ inputs.platforms }}
           file: ${{ inputs.dockerfile }}
-          build-args: ${{ fromJSON(inputs.build_args) }}
+          build-args: |
+            ${{ inputs.build_args}}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -115,6 +114,7 @@ jobs:
           target: ${{ inputs.extra_tag }}
           platforms: ${{ inputs.platforms }}
           file: ${{ inputs.dockerfile }}
-          build-args: ${{ fromJSON(inputs.extra_build_args) }}
+          build-args: |
+            ${{ inputs.extra_build_args }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -30,6 +30,9 @@ on:
       build_args:
         type: string
         default: "[]"
+      extra_build_args:
+        type: string
+        default: "[]"
 
 env:
   REGISTRY: ${{ inputs.registry }}
@@ -112,6 +115,6 @@ jobs:
           target: ${{ inputs.extra_tag }}
           platforms: ${{ inputs.platforms }}
           file: ${{ inputs.dockerfile }}
-          build-args: ${{ fromJSON(inputs.build_args) }}
+          build-args: ${{ fromJSON(inputs.extra_build_args) }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -24,6 +24,12 @@ on:
         type: string
         required: false
         default: linux/amd64
+      dockerfile:
+        type: string
+        default: Dockerfile
+      build_args:
+        type: string
+        default: "[]"
 
 env:
   REGISTRY: ${{ inputs.registry }}
@@ -44,7 +50,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -73,7 +79,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
             type=ref,event=branch
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
@@ -81,6 +87,10 @@ jobs:
           labels: ${{ steps.base_meta.outputs.labels }}
           target: ${{ inputs.base_tag }}
           platforms: ${{ inputs.platforms }}
+          file: ${{ inputs.dockerfile }}
+          build-args: ${{ fromJSON(inputs.build_args) }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Extract metadata for extra Docker
         if: "${{ inputs.extra_tag != '' }}"
@@ -93,7 +103,7 @@ jobs:
             type=ref,event=branch
       - name: Build and push extra Docker image
         if: "${{ inputs.extra_tag != '' }}"
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
@@ -101,3 +111,7 @@ jobs:
           labels: ${{ steps.extra_meta.outputs.labels }}
           target: ${{ inputs.extra_tag }}
           platforms: ${{ inputs.platforms }}
+          file: ${{ inputs.dockerfile }}
+          build-args: ${{ fromJSON(inputs.build_args) }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
# Description
Update GHA versions to latest releases
Add optional `dockerfile` input for non-default dockerfiles
Add optional `build_args` input to support Docker build-args
Add caching to Docker builds

# Issues
Closes #59 

# Other Notes
https://github.com/NeonGeckoCom/neon-iris/pull/51 should be updated to use this shared action
Testing: https://github.com/NeonDaniel/neon-iris/actions/workflows/publish_test_build.yml