### PR TITLE
Update build tests to use buildx and support multiple platforms

### DIFF
--- a/.github/workflows/docker_build_tests.yml
+++ b/.github/workflows/docker_build_tests.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           platforms: ${{ inputs.platforms }}
       - name: Build image
-        run: docker build --platform=${{ inputs.platforms }} .
+        run: docker buildx build --platform=${{ inputs.platforms }} .

--- a/.github/workflows/docker_build_tests.yml
+++ b/.github/workflows/docker_build_tests.yml
@@ -5,6 +5,10 @@ on:
       runner:
         type: string
         default: "ubuntu-latest"
+      platforms:
+        type: string
+        required: false
+        default: linux/amd64
 jobs:
   docker_build_tests:
     timeout-minutes: 15
@@ -12,7 +16,9 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: Build image
-        run: docker build .
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          platforms: ${{ inputs.platforms }}
+      - name: Build image
+        run: docker build --platform=${{ inputs.platforms }} .

--- a/.github/workflows/docker_build_tests.yml
+++ b/.github/workflows/docker_build_tests.yml
@@ -17,8 +17,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           platforms: ${{ inputs.platforms }}
+          install: true
       - name: Build image
-        run: docker buildx build --platform=${{ inputs.platforms }} .
+        run: docker build --platform=${{ inputs.platforms }} .


### PR DESCRIPTION
# Description
Add option to run docker build tests on multiple platforms
Adds test support to go with https://github.com/NeonGeckoCom/.github/pull/62

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Validated with https://github.com/NeonGeckoCom/neon_messagebus/pull/76