### PR TITLE
Extend Docker build test timeout

### DIFF
--- a/.github/workflows/docker_build_tests.yml
+++ b/.github/workflows/docker_build_tests.yml
@@ -11,7 +11,7 @@ on:
         default: linux/amd64
 jobs:
   docker_build_tests:
-    timeout-minutes: 15
+    timeout-minutes: 60
     runs-on: ${{inputs.runner}}
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
# Description
Extends Docker build timeout to 60 minutes to account for multiple platform tests

# Issues
https://github.com/NeonGeckoCom/NeonCore/actions/runs/7659582255/job/20876710245

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->