### PR TITLE
Add weekly issue automation and add "Triage" label to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,7 @@ description: Report a bug
 title: "[BUG] "
 labels:
   - bug
+  - triage
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,6 +3,7 @@ description: Request a new feature
 title: "[FEAT] "
 labels:
   - enhancement
+  - triage
 body:
   - type: textarea
     id: objective

--- a/.github/workflows/get_issues.yml
+++ b/.github/workflows/get_issues.yml
@@ -1,7 +1,7 @@
 name: Get Organization Issues
 on:
   schedule:
-    - cron: '0 9 * * *'
+    - cron: '0 16 * * *'
   workflow_dispatch:
   pull_request:
 jobs:

--- a/.github/workflows/get_issues.yml
+++ b/.github/workflows/get_issues.yml
@@ -1,7 +1,7 @@
 name: Get Organization Issues
 on:
   schedule:
-    - cron: '0 16 * * *'
+    - cron: '0 16 * * 1'
   workflow_dispatch:
   pull_request:
 jobs:

--- a/.github/workflows/get_issues.yml
+++ b/.github/workflows/get_issues.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
+          cache: pip
       - name: Install Issue Tracker
         run: |
           python -m pip install action/issue_tracker

--- a/.github/workflows/get_issues.yml
+++ b/.github/workflows/get_issues.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: '0 9 * * *'
   workflow_dispatch:
+  pull_request:
 jobs:
   get_issues:
     timeout-minutes: 15

--- a/.github/workflows/get_issues.yml
+++ b/.github/workflows/get_issues.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Checkout Issue Tracker Repository
         uses: actions/checkout@v4
         with:
           path: action/issue_tracker/
@@ -25,10 +25,11 @@ jobs:
         run: |
           python action/issue_tracker/github_issue_tracker/main.py
         env:
+          CSV_FILENAME: /tmp/issues.csv
           GH_ORGANIZATION: NeonGeckoCom
           GH_TOKEN: ${{ github.token }}
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:
           name: Open Issues
-          path: neongeckocom_issues.csv
+          path: /tmp/issues.csv

--- a/.github/workflows/get_issues.yml
+++ b/.github/workflows/get_issues.yml
@@ -1,0 +1,33 @@
+name: Get Organization Issues
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+jobs:
+  get_issues:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          path: action/issue_tracker/
+          repository: mikejgray/github-issue-tracker
+      - name: Set up python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - name: Install Issue Tracker
+        run: |
+          python -m pip install action/issue_tracker
+      - name: Get Issues
+        run: |
+          python action/issue_tracker/github_issue_tracker/main.py
+        env:
+          GH_ORGANIZATION: NeonGeckoCom
+          GH_TOKEN: ${{ github.token }}
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: Open Issues
+          path: neongeckocom_issues.csv


### PR DESCRIPTION
# Description
Automatically aggregates all issues under the org on a weekly basis and outputs a csv file
Adds an automatic "Triage" label to any new issues created with a template

# Issues
Relates to https://github.com/NeonGeckoCom/neon-docs/pull/47

# Other Notes
- How can the generated output be parsed into something actionable?
- ~Should this run weekly rather than daily?~ Done.
- ~Can new issues be identified or flagged for triage?~ Label added.