### PR TITLE
Update release automations to use current versions of shared actions

### DIFF
--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -74,7 +74,7 @@ jobs:
           path: action/github/
           repository: NeonGeckoCom/.github
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Increment Alpha Version
@@ -94,7 +94,7 @@ jobs:
         run: |
           python action/package/${{ inputs.on_version_change }} ${{ steps.version.outputs.version }}
       - name: Push Version Change
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Increment Version to ${{ steps.version.outputs.version }}
           repository: action/package/
@@ -127,7 +127,7 @@ jobs:
           maxIssues: ${{ inputs.changelog_max_issues }}
           sinceTag: ${{ steps.latest_release.outputs.release }}
       - name: Push Changelog
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Update Changelog
           repository: action/package/
@@ -149,7 +149,7 @@ jobs:
           path: action/github/
           repository: NeonGeckoCom/.github
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install Build Tools
@@ -162,7 +162,7 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages_dir: action/package/dist/
+          packages-dir: action/package/dist/
           password: ${{secrets.PYPI_TOKEN}}
   tag_prerelease:
     needs:


### PR DESCRIPTION
# Description
Update `publish_alpha_release` to use current shared action versions

# Issues
Warnings noted in https://github.com/NeonGeckoCom/skill-caffeinewiz/actions/runs/10927092034

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->