### PR TITLE
Update license tests to use current actions and Python versions

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -8,6 +8,9 @@ on:
       package-extras:
         required: false
         type: string
+      python-version:
+        type: string
+        default: 3.12
       packages-exclude:
         type: string
         default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct).*'
@@ -19,11 +22,11 @@ jobs:
     timeout-minutes: 15
     runs-on: ${{inputs.runner}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: ${{inputs.python-version}}
       - name: Install Build Tools
         run: |
           python -m pip install build wheel


### PR DESCRIPTION
# Description
Update actions versions to latest stable
Make Python version configurable and update default to 3.12

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Issue noted and fix validated: https://github.com/NeonGeckoCom/brainforge-webapp/actions/runs/12640463931/job/35220925786