### PR TITLE
Whitelist attrs package

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -13,7 +13,7 @@ on:
         default: 3.12
       packages-exclude:
         type: string
-        default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct).*'
+        default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|attrs).*'
       licenses-exclude:
         type: string
         default: '^(Mozilla|NeonAI License v1.0).*$'


### PR DESCRIPTION
# Description
attrs is MIT licensed as indicated [on PyPI](https://pypi.org/project/attrs/) and [GitHub](https://github.com/python-attrs/attrs?tab=MIT-1-ov-file)

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Validated change with https://github.com/OpenVoiceOS/ovos-PHAL-plugin-wallpaper-manager/actions/runs/13001758587/job/36261628131?pr=24