### PR TITLE
Make Dockerfile configurable in Docker build tests

### DIFF
--- a/.github/workflows/docker_build_tests.yml
+++ b/.github/workflows/docker_build_tests.yml
@@ -9,6 +9,9 @@ on:
         type: string
         required: false
         default: linux/amd64
+      dockerfile:
+        type: string
+        default: Dockerfile
 jobs:
   docker_build_tests:
     timeout-minutes: 60
@@ -22,4 +25,4 @@ jobs:
           platforms: ${{ inputs.platforms }}
           install: true
       - name: Build image
-        run: docker build --platform=${{ inputs.platforms }} .
+        run: docker build --platform=${{ inputs.platforms }} -f ${{inputs.dockerfile}} .


### PR DESCRIPTION
# Description
Make Dockerfile configurable in Docker build tests

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Tested with https://github.com/NeonGeckoCom/neon-nodes/actions/runs/13556315621/job/37891243507?pr=19