### PR TITLE
Exclude RapidFuzz from license tests by default

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -13,7 +13,7 @@ on:
         default: 3.12
       packages-exclude:
         type: string
-        default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|attrs).*'
+        default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|attrs|RapidFuzz).*'
       licenses-exclude:
         type: string
         default: '^(Mozilla|NeonAI License v1.0).*$'


### PR DESCRIPTION
# Description
[Per PyPI](https://pypi.org/project/RapidFuzz/) `RapidFuzz` carries an MIT license

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Addresses [test failures](https://github.com/NeonGeckoCom/neon-messagebus-mq-connector/actions/runs/13778081973/job/38531174343?pr=56)