### PR TITLE
Whitelist `typing_extensions` in License tests

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -13,7 +13,7 @@ on:
         default: 3.12
       packages-exclude:
         type: string
-        default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|attrs|RapidFuzz).*'
+        default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|attrs|RapidFuzz|typing_extensions).*'
       licenses-exclude:
         type: string
         default: '^(Mozilla|NeonAI License v1.0).*$'


### PR DESCRIPTION
# Description
`typing_extensions` uses the PSF license which applies to Python already, so should be allowed here

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Validated with: https://github.com/NeonGeckoCom/neon-messagebus-mq-connector/actions/runs/14116049124/job/39546412794?pr=61