### PR TITLE
Added support for `fetch-depth` parameter

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -34,6 +34,9 @@ on:
         type: string
       extra_build_args:
         type: string
+      fetch_depth:
+        type: number
+        default: 1
 
 env:
   REGISTRY: ${{ inputs.registry }}
@@ -52,6 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+          fetch-depth: ${{ inputs.fetch_depth }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3


### PR DESCRIPTION
# Description
This change will allow dependant repos to dynamically insert commits (e.g. to build artifacts) before running the docker deployment

# Issues
By default if any new commits are introduced during the workflow - they are being ignored

# Other Notes
this parameter will default to `1` which will preserve consistency for dependencies