### PR TITLE
Fix typo in intent test OVOS versions

### DIFF
--- a/.github/workflows/skill_test_intents.yml
+++ b/.github/workflows/skill_test_intents.yml
@@ -25,7 +25,7 @@ on:
         default: "[ 3.9, '3.10', '3.11' ]"
       ovos_versions:
         type: string
-        default: "[ '3.10' '3.11' ]"
+        default: "[ '3.10', '3.11' ]"
 jobs:
   test_intents_ovos:
     if: "${{ inputs.ovos_versions != '' }}"


### PR DESCRIPTION
# Description
Adds a missing `,` in default `ovos_versions` parameter

# Issues
Missed in #88

# Other Notes
Noted by @NeonDmitry in https://github.com/NeonGeckoCom/skill-weather_intents/actions/runs/15282658265