### PR TITLE
Whitelist `click` and `setuptools`

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -13,7 +13,7 @@ on:
         default: "3.12"
       packages-exclude:
         type: string
-        default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|attrs|RapidFuzz|typing_extensions|audioread|urllib3).*'
+        default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|attrs|RapidFuzz|typing_extensions|audioread|urllib3|setuptools|click).*'
       licenses-exclude:
         type: string
         default: '^(Mozilla|NeonAI License v1.0).*$'


### PR DESCRIPTION
# Description
`setuptools` is [MIT licensed](https://pypi.org/project/setuptools/)
`click` is [BSD-3 licensed](https://pypi.org/project/click/)

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Validated with [skill-weather](https://github.com/NeonGeckoCom/skill-weather/actions/runs/15286374590/job/42997352590?pr=69)