### PR TITLE
Whitelist `typing-inspection` with MIT license

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -13,7 +13,7 @@ on:
         default: "3.12"
       packages-exclude:
         type: string
-        default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|attrs|RapidFuzz|typing_extensions|audioread|urllib3|setuptools|click).*'
+        default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|attrs|RapidFuzz|typing_extensions|audioread|urllib3|setuptools|click|typing-inspection).*'
       licenses-exclude:
         type: string
         default: '^(Mozilla|NeonAI License v1.0).*$'


### PR DESCRIPTION
# Description
MIT license [per PyPI](https://pypi.org/project/typing-inspection/)

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Validated with https://github.com/NeonGeckoCom/neon-data-models/actions/runs/15287195675/job/42999832701?pr=24