### PR TITLE
Add optional input for an additional Docker image tag

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -89,9 +89,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            ${{ inputs.image_tag == '' && format('type=semver,pattern={{version}},value={0}', steps.version.outputs.version) }}
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
             type=ref,event=branch
-            ${{ inputs.image_tag && format('type=raw,{0}', inputs.image_tag) }}
       - name: Extract metadata for base Docker (no semver)
         if: ${{ !inputs.include_semver }}
         id: base_meta_no_semver
@@ -100,6 +99,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
+            ${{ inputs.image_tag && format('type=raw,{0}', inputs.image_tag) }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -134,6 +134,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ inputs.extra_tag }}
           tags: |
             type=ref,event=branch
+            ${{ inputs.image_tag && format('type=raw,{0}', inputs.image_tag) }}
 
       - name: Build and push extra Docker image
         if: "${{ inputs.extra_tag != '' }}"


### PR DESCRIPTION
# Description
Add optional "image_tag" input to allow for specifying an additional tag in Docker GHA

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
This can be used to push an "alpha" image using automation from any branch, via GHA
Tested with [this build](https://github.com/NeonDaniel/pyklatchat-observer/actions/runs/15569139123) and the latest published image: https://github.com/NeonDaniel/pyklatchat-observer/pkgs/container/pyklatchat-observer