### PR TITLE
Add support for "__version_ts__" timestamp in version_bump automation

### DIFF
--- a/scripts/oneline_semantic_version_bump.py
+++ b/scripts/oneline_semantic_version_bump.py
@@ -81,6 +81,9 @@ def bump_version(version_file: str, version_spec: str):
     for line in fileinput.input(version_file, inplace=True):
         if line.startswith("__version__"):
             print(f"__version__ = \"{version}\"")
+        elif line.startswith("__version_ts__"):
+            from time import time
+            print(f"__version_ts__ = {int(time())}")
         else:
             print(line.rstrip('\n'))
 


### PR DESCRIPTION
# Description
Adds support for updating timestamps in version files as part of semantic version bump automation

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Implementation from https://github.com/NeonGeckoCom/pyklatchat-client/blob/c624522de7ea521621989de82f713753dd5e24ed/chat_client/version.py