### PR TITLE
Whitelist `zipp` in license_tests with MIT license

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -13,7 +13,7 @@ on:
         default: "3.12"
       packages-exclude:
         type: string
-        default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|attrs|RapidFuzz|typing_extensions|audioread|urllib3|setuptools|click|typing-inspection).*'
+        default: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|attrs|RapidFuzz|typing_extensions|audioread|urllib3|setuptools|click|typing-inspection|zipp).*'
       licenses-exclude:
         type: string
         default: '^(Mozilla|NeonAI License v1.0).*$'


### PR DESCRIPTION
# Description
Confirmed MIT license at https://pypi.org/project/zipp/

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Failure noted in https://github.com/NeonGeckoCom/neon_gui/actions/runs/15740510281/job/44364386900?pr=68