### PR TITLE
Increase Docker build test timeout

### DIFF
--- a/.github/workflows/docker_build_tests.yml
+++ b/.github/workflows/docker_build_tests.yml
@@ -13,7 +13,7 @@ on:
         type: string
         default: Dockerfile
       build_timeout:
-        type: int
+        type: number
         default: 60
 jobs:
   docker_build_tests:

--- a/.github/workflows/docker_build_tests.yml
+++ b/.github/workflows/docker_build_tests.yml
@@ -12,9 +12,12 @@ on:
       dockerfile:
         type: string
         default: Dockerfile
+      build_timeout:
+      type: int
+      default: 60
 jobs:
   docker_build_tests:
-    timeout-minutes: 120
+    timeout-minutes: ${{ inputs.build_timeout }}
     runs-on: ${{inputs.runner}}
     steps:
       - name: Checkout Repository

--- a/.github/workflows/docker_build_tests.yml
+++ b/.github/workflows/docker_build_tests.yml
@@ -14,7 +14,7 @@ on:
         default: Dockerfile
 jobs:
   docker_build_tests:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ${{inputs.runner}}
     steps:
       - name: Checkout Repository

--- a/.github/workflows/docker_build_tests.yml
+++ b/.github/workflows/docker_build_tests.yml
@@ -13,8 +13,8 @@ on:
         type: string
         default: Dockerfile
       build_timeout:
-      type: int
-      default: 60
+        type: int
+        default: 60
 jobs:
   docker_build_tests:
     timeout-minutes: ${{ inputs.build_timeout }}


### PR DESCRIPTION
# Description
Increase Docker Build tests timeout from 60 t0 120 Minutes

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Timeout observed in [NeonCore Test Run](https://github.com/NeonGeckoCom/NeonCore/actions/runs/16976026627/job/48129025364?pr=750)
- Validated with: https://github.com/NeonGeckoCom/NeonCore/actions/runs/16980082287/job/48138065323