### PR TITLE
Update PyPI Automations

### DIFF
--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -69,14 +69,14 @@ jobs:
           ref: ${{ inputs.branch }}
           path: action/package/
       - name: Checkout Scripts Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: action/github/
           repository: NeonGeckoCom/.github
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Increment Alpha Version
         id: version
         run: |
@@ -106,7 +106,7 @@ jobs:
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           path: action/package/
@@ -139,19 +139,19 @@ jobs:
     runs-on: ${{inputs.runner}}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           path: action/package/
       - name: Checkout Scripts Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: action/github/
           repository: NeonGeckoCom/.github
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Install Build Tools
         run: |
           python -m pip install build wheel
@@ -172,7 +172,7 @@ jobs:
     runs-on: ${{inputs.runner}}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           path: action/package/

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -168,7 +168,7 @@ jobs:
           packages-dir: action/package/dist/
           password: ${{secrets.PYPI_TOKEN}}
           repository-url: ${{ inputs.pypi_url }}
-          verbose: true
+          attestations: false
   tag_prerelease:
     needs:
       - update_changelog

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -157,7 +157,7 @@ jobs:
           python-version: "3.14"
       - name: Install Build Tools
         run: |
-          python -m pip install build wheel
+          python -m pip install build wheel setuptools
       - name: Build Distribution Packages
         run: |
           cd action/package

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -26,6 +26,9 @@ on:
       publish_pypi:
         type: boolean
         default: True
+      pypi_url:
+        type: string
+        default: "https://upload.pypi.org/legacy/"
       version_scheme:
         type: string
         default: semver
@@ -164,6 +167,7 @@ jobs:
         with:
           packages_dir: action/package/dist/
           password: ${{secrets.PYPI_TOKEN}}
+          repository-url: ${{ inputs.pypi_url }}
   tag_prerelease:
     needs:
       - update_changelog

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -94,7 +94,7 @@ jobs:
           elif [ ${{ inputs.version_scheme }} == "dated" ]; then
             python action/github/scripts/dated_version_bump.py action/package/${{ inputs.version_file }} true
           fi
-          echo ::set-output name=version::$(python action/package/${{ inputs.setup_py }} --version)
+          echo "version=$(python action/package/${{ inputs.setup_py }} --version)" >> $GITHUB_OUTPUT
       - name: Run Extra Update Script
         if: "${{ inputs.on_version_change != '' }}"
         run: |

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -165,9 +165,10 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages_dir: action/package/dist/
+          packages-dir: action/package/dist/
           password: ${{secrets.PYPI_TOKEN}}
           repository-url: ${{ inputs.pypi_url }}
+          verbose: true
   tag_prerelease:
     needs:
       - update_changelog

--- a/.github/workflows/publish_alpha_release.yml
+++ b/.github/workflows/publish_alpha_release.yml
@@ -67,7 +67,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           path: action/package/
@@ -80,6 +80,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
+      - name: Install Build Tools
+        run: |
+          python -m pip install setuptools
       - name: Increment Alpha Version
         id: version
         run: |

--- a/.github/workflows/publish_stable_release.yml
+++ b/.github/workflows/publish_stable_release.yml
@@ -26,11 +26,11 @@ jobs:
     runs-on: ${{inputs.runner}}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Install Build Tools
         run: |
           python -m pip install build wheel

--- a/.github/workflows/publish_stable_release.yml
+++ b/.github/workflows/publish_stable_release.yml
@@ -41,3 +41,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{secrets.PYPI_TOKEN}}
+          attestations: false

--- a/.github/workflows/publish_stable_release.yml
+++ b/.github/workflows/publish_stable_release.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: "3.14"
       - name: Install Build Tools
         run: |
-          python -m pip install build wheel
+          python -m pip install build wheel setuptools
       - name: Build Distribution Packages
         run: |
           python setup.py sdist bdist_wheel


### PR DESCRIPTION
# Description
Updates Alpha and Stable release actions to latest supported Python (3.14) and latest shared actions versions
Updates deprecated `set-output` command in Alpha action to new syntax
Updates Alpha action to enable input PyPI repository for uploading to test PyPI

# Issues
Addresses failure [reported](https://matrix.to/#/!EOygeDJPfJQOfNacqH:matrix.org/$6x577Inxo4opi-xCapQHLDmKQw2YnKL2p7nxhAUODhs?via=matrix.org&via=tchncs.de&via=mozilla.org) by @JarbasAl 

# Other Notes
Tested with https://github.com/NeonDaniel/skill-speak/actions/runs/18848277094