### PR TITLE
Update license tests

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -13,7 +13,7 @@ on:
         default: "3.12"
       packages-exclude:
         type: string
-        default: '^(fann2|neon-core|neon-phal-plugin|ovos-phal-plugin|ovos-skill|precise-runner|tqdm|marisa-trie).*'
+        default: '^(orjson|fann2|neon-core|neon-phal-plugin|ovos-phal-plugin|ovos-skill|precise-runner|tqdm|marisa-trie).*'
       licenses-exclude:
         type: string
         default: '^(PSF-2.0|MPL|Mozilla|NeonAI License v1.0).*'


### PR DESCRIPTION
# Description
Exclude `orjson` which has Apache, MIT, MPL 2.0 listed

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
- Tested with https://github.com/NeonGeckoCom/skill-fallback_wolfram_alpha/actions/runs/22464228194/job/65066171917?pr=53