### PR TITLE
Respect destination_branch input to pull_master workflow

### DIFF
--- a/.github/workflows/pull_master.yml
+++ b/.github/workflows/pull_master.yml
@@ -36,3 +36,4 @@ jobs:
           pr_draft: ${{ inputs.pr_draft }}
           pr_title: ${{ inputs.pr_title }}
           pr_body: ${{ inputs.pr_body }}
+          destination_branch: ${{ inputs.destination }}


### PR DESCRIPTION
# Description
Fix error in `pull_master.yml` that was ignoring the input `destination` branch

# Issues


# Other Notes
- Observed in https://github.com/NeonGeckoCom/CCAI-Demo/actions/runs/27223508075